### PR TITLE
feat: conda installation, remove libraqm requirement

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -10,6 +10,7 @@ import threading
 import queue
 import torch
 import math
+import sys
 
 from utils.scrollable_image import ScrollableImage
 from utils.tooltip import Tooltip
@@ -271,8 +272,8 @@ def TOAD_GUI():
                     l_draw.multiline_text((1, 4+y*16), str(y), (255, 255, 255),
                                           stroke_width=-1, stroke_fill=(0, 0, 0))
                 for x in range(level_obj.oh_level.shape[-1]):
-                    l_draw.multiline_text((6+x*16, 0), "".join(["%s\n" % c for c in str(x)]), (255, 255, 255),
-                                          stroke_width=-1, stroke_fill=(0, 0, 0), direction='ttb', spacing=0,
+                    l_draw.multiline_text((6+x*16, 0), '\n'.join(list(str(x))), (255,255,255),
+                                          stroke_width=-1, stroke_fill=(0, 0, 0),  spacing=3,
                                           align='right')
                 # Add bounding box rectangle
                 l_draw.rectangle(rectangle, outline=(255, 0, 0), width=2)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,8 +1,0 @@
-
-```sh
-conda env create -f environment.yml
-conda activate toad-gui
-python main.py
-```
-
-If the program does fail to start, ensure that `torch` is NOT installed globally. If it is, remove it and retry running.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,8 @@
+
+```sh
+conda env create -f environment.yml
+conda activate toad-gui
+python main.py
+```
+
+If the program does fail to start, ensure that `torch` is NOT installed globally. If it is, remove it and retry running.

--- a/README.md
+++ b/README.md
@@ -49,12 +49,11 @@ $ pip3 install -r requirements.txt -f "https://download.pytorch.org/whl/torch_st
 Make sure you use the `pip3` that belongs to your previously defined virtual environment.
 
 The GUI is made with [Tkinter](https://wiki.python.org/moin/TkInter), which from Python 3.7 onwards is installed by default.
-
 If you don't have it installed because of an older version, follow the instructions [here](https://tkdocs.com/tutorial/install.html).
 
 #### Conda
 
-Alternatively, you can also install an environment with [`conda`](https://docs.anaconda.com/free/anaconda/install/):
+Alternatively, you can install an environment with [`conda`](https://docs.anaconda.com/free/anaconda/install/):
 
 You can modify the conda `environment.yml` file, to e.g. use a different Python version than 3.11.5.
 
@@ -63,7 +62,7 @@ $ conda env create -f environment.yml
 $ conda activate toad-gui
 ```
 
-If the program fails to start, ensure that `torch` is **not** installed globally, as the global version might take preference over the on in the environment.
+If the program fails to start, ensure that `torch` is **not** installed globally, as the global version might take precedence over the on in the environment.
 
 ### Java
 

--- a/README.md
+++ b/README.md
@@ -36,17 +36,34 @@ This section includes the necessary steps to get TOAD-GUI running on your system
 
 ### Python
 
+#### PIP
+
 You will need [Python 3](https://www.python.org/downloads) and the packages specified in requirements.txt.
-We recommend setting up a [virtual environment with pip](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/)
-and installing the packages there.
+
+We recommend setting up a [virtual environment with pip](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/) and installing the packages there.
 
 ```
 $ pip3 install -r requirements.txt -f "https://download.pytorch.org/whl/torch_stable.html"
 ```
+
 Make sure you use the `pip3` that belongs to your previously defined virtual environment.
 
 The GUI is made with [Tkinter](https://wiki.python.org/moin/TkInter), which from Python 3.7 onwards is installed by default.
+
 If you don't have it installed because of an older version, follow the instructions [here](https://tkdocs.com/tutorial/install.html).
+
+#### Conda
+
+Alternatively, you can also install an environment with [`conda`](https://docs.anaconda.com/free/anaconda/install/):
+
+You can modify the conda `environment.yml` file, to e.g. use a different Python version than 3.11.5.
+
+```
+$ conda env create -f environment.yml
+$ conda activate toad-gui
+```
+
+If the program fails to start, ensure that `torch` is **not** installed globally, as the global version might take preference over the on in the environment.
 
 ### Java
 
@@ -57,7 +74,7 @@ For the Framework to run, [Java 11](https://adoptopenjdk.net/releases.html) (or 
 
 Once all prerequisites are installed, TOAD-GUI can be started by running main.py.
 ```
-$ python main.py
+$ python3 main.py
 ```
 Make sure you are using the python installation you installed the prerequisites into.
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,13 @@
+name: toad-gui
+channels:
+  - pytorch
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.11.5
+  - pip
+  - pytorch
+  - pip:
+    - numpy
+    - Pillow
+    - py4j

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Pillow>=7.1.2
-py4j>=0.10.9
-numpy>=1.18.5
-torch===1.5.0+cpu
+Pillow
+py4j
+numpy
+torch


### PR DESCRIPTION
- Conda env + environment installation notice
- removes requirement to `libraqm` system package for text positioning (`direction='ttb'`) by using a basic spacing

If you want to, I can include the installation instructions in the README & remove the requirements.txt